### PR TITLE
Extensive changes

### DIFF
--- a/Client/XmppClient.cs
+++ b/Client/XmppClient.cs
@@ -20,6 +20,16 @@ namespace Sharp.Xmpp.Client
     public class XmppClient : IDisposable
     {
         /// <summary>
+        /// If false the connection will not try to retrieve the rooster automatically
+        /// </summary>
+        public bool UseRooster
+        {
+            get { return im.UseRoster; }
+            set { im.UseRoster = value; }
+        }
+        
+
+        /// <summary>
         /// True if the instance has been disposed of.
         /// </summary>
         private bool disposed;
@@ -225,7 +235,7 @@ namespace Sharp.Xmpp.Client
         /// <summary>
         /// If true the session will be TLS/SSL-encrypted if the server supports it.
         /// </summary>
-        public bool Tls
+        public Core.TLSMode Tls
         {
             get
             {
@@ -452,6 +462,21 @@ namespace Sharp.Xmpp.Client
         }
 
         /// <summary>
+        /// The event that is raised when a bodyless message is received.
+        /// </summary>
+        public event EventHandler<MessageEventArgs> BodylessMessage
+        {
+            add
+            {
+                im.BodylessMessage += value;
+            }
+            remove
+            {
+                im.BodylessMessage -= value;
+            }
+        }
+
+        /// <summary>
         /// The event that is raised periodically for every file-transfer operation to
         /// inform subscribers of the progress of the operation.
         /// </summary>
@@ -600,7 +625,7 @@ namespace Sharp.Xmpp.Client
         /// <remarks>Use this constructor if you wish to connect to an XMPP server using
         /// an existing set of user credentials.</remarks>
         public XmppClient(string hostname, string username, string password,
-            int port = 5222, bool tls = true, RemoteCertificateValidationCallback validate = null)
+            int port = 5222, Core.TLSMode tls = Core.TLSMode.StartTLS, RemoteCertificateValidationCallback validate = null)
         {
             im = new XmppIm(hostname, username, password, port, tls, validate);
             // Initialize the various extension modules.
@@ -625,7 +650,7 @@ namespace Sharp.Xmpp.Client
         /// is not a valid port number.</exception>
         /// <remarks>Use this constructor if you wish to register an XMPP account using
         /// the in-band account registration process supported by some servers.</remarks>
-        public XmppClient(string hostname, int port = 5222, bool tls = true,
+        public XmppClient(string hostname, int port = 5222, Xmpp.Core.TLSMode tls = Core.TLSMode.StartTLS,
             RemoteCertificateValidationCallback validate = null)
         {
             im = new XmppIm(hostname, port, tls, validate);

--- a/Core/StreamParser.cs
+++ b/Core/StreamParser.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml;
 
 namespace Sharp.Xmpp.Core
@@ -53,6 +54,7 @@ namespace Sharp.Xmpp.Core
         /// XML-stream in it's 'xml:lang' attribute could not be found.</exception>
         public StreamParser(Stream stream, bool leaveOpen = false)
         {
+            
             stream.ThrowIfNull("stream");
             this.leaveOpen = leaveOpen;
             this.stream = stream;

--- a/Im/Message.cs
+++ b/Im/Message.cs
@@ -254,6 +254,20 @@ namespace Sharp.Xmpp.Im
         }
 
         /// <summary>
+        /// Initializes a new instance of the Message class from the specified
+        /// instance.
+        /// </summary>
+        /// <param name="data">The message element</param>
+        /// <exception cref="ArgumentNullException">The Data parameter is null.</exception>
+        public Message(XmlElement data)
+        {
+
+            Data.ThrowIfNull("data");
+            type = ParseType(data.GetAttribute("type"));
+            element = data;
+        }
+
+        /// <summary>
         /// Parses the Message type from the specified string.
         /// </summary>
         /// <param name="value">The string to parse.</param>

--- a/Im/MessageEventArgs.cs
+++ b/Im/MessageEventArgs.cs
@@ -37,5 +37,15 @@ namespace Sharp.Xmpp.Im
             Jid = jid;
             Message = message;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the MessageEventArgs class for bodyless messages.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">The message parameter is null.</exception>
+        public MessageEventArgs(Message message)
+        {
+            message.ThrowIfNull("message");
+            Message = message;
+        }
     }
 }

--- a/Sharp.Xmpp.csproj
+++ b/Sharp.Xmpp.csproj
@@ -52,8 +52,12 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ARSoft.Tools.Net, Version=1.8.1.0, Culture=neutral, PublicKeyToken=1940454cd762ec57, processorArchitecture=MSIL">
-      <HintPath>packages\ARSoft.Tools.Net.1.8.1\lib\ARSoft.Tools.Net.dll</HintPath>
+    <Reference Include="ARSoft.Tools.Net, Version=2.2.4.0, Culture=neutral, PublicKeyToken=1940454cd762ec57, processorArchitecture=MSIL">
+      <HintPath>..\packages\ARSoft.Tools.Net.2.2.4\lib\net45\ARSoft.Tools.Net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Xml.cs
+++ b/Xml.cs
@@ -10,7 +10,7 @@ namespace Sharp.Xmpp
     /// Provides a factory method for creating XmlElement instances and adds
     /// a couple of useful shortcut extensions to the XmlElement class.
     /// </summary>
-    internal static class Xml
+    public static class Xml
     {
         /// <summary>
         /// Creates a new XmlElement instance.

--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ARSoft.Tools.Net" version="1.8.1" targetFramework="net45" />
+  <package id="ARSoft.Tools.Net" version="2.2.4" targetFramework="net45" />
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Current changes:

1-Added a new constructor to IM.Message which allows to create a message from an XmlElement
2-Left the Xmpp.Xml namespace public to allow to use the functions to create/append Xml elements
3-Implemented a new event named BodylessMessage which receives messages with no body
4-BodylessMessage uses MessageEventArgs, for that I created a new constructor which does not require a Jid as these messages come without an ID (they come from the server itself, not from an user)
6-Created a property on the connection to disable roster retrieval when connection is created.
7-Created a public function to send a default Presence stanza as the usual with no roster is to not send the presence, but in case some service uses it without roster the function is available.
8-Changed Tls from bool to enum, this allows to use StartTLS extension or Ssl sockets.
9-Updated ArSoft.Tools.Net reference