### PR TITLE
Set JID for IqRequest

### DIFF
--- a/Im/XmppIm.cs
+++ b/Im/XmppIm.cs
@@ -714,7 +714,7 @@ namespace Sharp.Xmpp.Im {
 			foreach (string group in item.Groups)
 				xml.Child(Xml.Element("group").Text(group));
 			var query = Xml.Element("query", "jabber:iq:roster").Child(xml);
-			Iq iq = IqRequest(IqType.Set, null, Jid, query);
+			Iq iq = IqRequest(IqType.Set, item.Jid, Jid, query);
 			if (iq.Type == IqType.Error)
 				throw Util.ExceptionFromError(iq, "The item could not be added to the roster.");
 		}


### PR DESCRIPTION
When using the `AddToRoster` functionality, the JID is not set for the IqRequest. This causes a NullReferenceException [here](https://github.com/pgstath/Sharp.Xmpp/blob/dev/Core/XmppCore.cs#L633) as it assumes the `To` JID has been set.

This PR ensures the ID is set from the roster item that is passed in
