### PR TITLE
Allow XMPP Server to be different from JID domain

### DIFF
--- a/Client/XmppClient.cs
+++ b/Client/XmppClient.cs
@@ -697,12 +697,38 @@ namespace Sharp.Xmpp.Client
         /// <remarks>Use this constructor if you wish to connect to an XMPP server using
         /// an existing set of user credentials.</remarks>
         public XmppClient(string hostname, string username, string password,
-            int port = 5222, bool tls = true, RemoteCertificateValidationCallback validate = null)
-        {
-            im = new XmppIm(hostname, username, password, port, tls, validate);
-            // Initialize the various extension modules.
-            LoadExtensions();
-        }
+            int port = 5222, bool tls = true, RemoteCertificateValidationCallback validate = null) :
+			this(hostname, username, password, null, port, tls, validate) { }
+
+		/// <summary>
+		/// Initializes a new instance of the XmppClient class.
+		/// </summary>
+		/// <param name="hostname">The hostname of the XMPP server to connect to.</param>
+		/// <param name="username">The username with which to authenticate. In XMPP jargon
+		/// this is known as the 'node' part of the JID.</param>
+		/// <param name="password">The password with which to authenticate.</param>
+		/// <param name="server">The IP address or domain of the XMPP server, if different from the hostname. eg. xmpp.server.com</param>
+		/// <param name="port">The port number of the XMPP service of the server.</param>
+		/// <param name="tls">If true the session will be TLS/SSL-encrypted if the server
+		/// supports TLS/SSL-encryption.</param>
+		/// <param name="validate">A delegate used for verifying the remote Secure Sockets
+		/// Layer (SSL) certificate which is used for authentication. Can be null if not
+		/// needed.</param>
+		/// <exception cref="ArgumentNullException">The hostname parameter or the
+		/// username parameter or the password parameter is null.</exception>
+		/// <exception cref="ArgumentException">The hostname parameter or the username
+		/// parameter is the empty string.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">The value of the port parameter
+		/// is not a valid port number.</exception>
+		/// <remarks>Use this constructor if you wish to connect to an XMPP server using
+		/// an existing set of user credentials.</remarks>
+		public XmppClient(string hostname, string username, string password, string server,
+			int port = 5222, bool tls = true, RemoteCertificateValidationCallback validate = null)
+		{
+			im = new XmppIm(hostname, username, password, server, port, tls, validate);
+			// Initialize the various extension modules.
+			LoadExtensions();
+		}
 
         /// <summary>
         /// Initializes a new instance of the XmppClient class.
@@ -723,11 +749,34 @@ namespace Sharp.Xmpp.Client
         /// <remarks>Use this constructor if you wish to register an XMPP account using
         /// the in-band account registration process supported by some servers.</remarks>
         public XmppClient(string hostname, int port = 5222, bool tls = true,
-            RemoteCertificateValidationCallback validate = null)
-        {
-            im = new XmppIm(hostname, port, tls, validate);
-            LoadExtensions();
-        }
+            RemoteCertificateValidationCallback validate = null) :
+			this(hostname, null, port, tls, validate) { }
+
+		/// <summary>
+		/// Initializes a new instance of the XmppClient class.
+		/// </summary>
+		/// <param name="hostname">The hostname of the XMPP server to connect to.</param>
+		/// <param name="server">The IP address or domain of the XMPP server, if different from the hostname eg. xmpp.server.com</param>
+		/// <param name="port">The port number of the XMPP service of the server.</param>
+		/// <param name="tls">If true the session will be TLS/SSL-encrypted if the server
+		/// supports TLS/SSL-encryption.</param>
+		/// <param name="validate">A delegate used for verifying the remote Secure Sockets
+		/// Layer (SSL) certificate which is used for authentication. Can be null if not
+		/// needed.</param>
+		/// <exception cref="ArgumentNullException">The hostname parameter is
+		/// null.</exception>
+		/// <exception cref="ArgumentException">The hostname parameter is the empty
+		/// string.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">The value of the port parameter
+		/// is not a valid port number.</exception>
+		/// <remarks>Use this constructor if you wish to register an XMPP account using
+		/// the in-band account registration process supported by some servers.</remarks>
+		public XmppClient(string hostname, string server, int port = 5222, bool tls = true,
+			RemoteCertificateValidationCallback validate = null)
+		{
+			im = new XmppIm(hostname, server, port, tls, validate);
+			LoadExtensions();
+		}
 
         /// <summary>
         /// Establishes a connection to the XMPP server.

--- a/Im/XmppIm.cs
+++ b/Im/XmppIm.cs
@@ -299,11 +299,36 @@ namespace Sharp.Xmpp.Im
         /// <exception cref="ArgumentOutOfRangeException">The value of the port parameter
         /// is not a valid port number.</exception>
         public XmppIm(string hostname, string username, string password,
-            int port = 5222, bool tls = true, RemoteCertificateValidationCallback validate = null)
-        {
-            core = new XmppCore(hostname, username, password, port, tls, validate);
-            SetupEventHandlers();
-        }
+            int port = 5222, bool tls = true, RemoteCertificateValidationCallback validate = null) :
+		this (hostname, username, password, null, port, tls, validate)
+        { }
+
+		/// <summary>
+		/// Initializes a new instance of the XmppIm.
+		/// </summary>
+		/// <param name="hostname">The hostname of the XMPP server to connect to.</param>
+		/// <param name="username">The username with which to authenticate. In XMPP jargon
+		/// this is known as the 'node' part of the JID.</param>
+		/// <param name="password">The password with which to authenticate.</param>
+		/// <param name="server">The IP address or domain of the XMPP server, if different from the hostname eg. xmpp.server.com</param>
+		/// <param name="port">The port number of the XMPP service of the server.</param>
+		/// <param name="tls">If true the session will be TLS/SSL-encrypted if the server
+		/// supports TLS/SSL-encryption.</param>
+		/// <param name="validate">A delegate used for verifying the remote Secure Sockets
+		/// Layer (SSL) certificate which is used for authentication. Can be null if not
+		/// needed.</param>
+		/// <exception cref="ArgumentNullException">The hostname parameter or the
+		/// username parameter or the password parameter is null.</exception>
+		/// <exception cref="ArgumentException">The hostname parameter or the username
+		/// parameter is the empty string.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">The value of the port parameter
+		/// is not a valid port number.</exception>
+		public XmppIm(string hostname, string username, string password, string server,
+			int port = 5222, bool tls = true, RemoteCertificateValidationCallback validate = null)
+		{
+			core = new XmppCore(hostname, username, password, server, port, tls, validate);
+			SetupEventHandlers();
+		}
 
         /// <summary>
         /// Initializes a new instance of the XmppIm.
@@ -322,11 +347,36 @@ namespace Sharp.Xmpp.Im
         /// <exception cref="ArgumentOutOfRangeException">The value of the port parameter
         /// is not a valid port number.</exception>
         public XmppIm(string hostname, int port = 5222, bool tls = true,
-            RemoteCertificateValidationCallback validate = null)
+            RemoteCertificateValidationCallback validate = null) :
+		this (hostname, null, port , tls, validate)
         {
             core = new XmppCore(hostname, port, tls, validate);
             SetupEventHandlers();
         }
+
+		/// <summary>
+		/// Initializes a new instance of the XmppIm.
+		/// </summary>
+		/// <param name="hostname">The hostname of the XMPP server to connect to.</param>
+		/// <param name="server">The IP address or domain of the XMPP server, if different from the hostname eg. xmpp.server.com</param>
+		/// <param name="port">The port number of the XMPP service of the server.</param>
+		/// <param name="tls">If true the session will be TLS/SSL-encrypted if the server
+		/// supports TLS/SSL-encryption.</param>
+		/// <param name="validate">A delegate used for verifying the remote Secure Sockets
+		/// Layer (SSL) certificate which is used for authentication. Can be null if not
+		/// needed.</param>
+		/// <exception cref="ArgumentNullException">The hostname parameter is
+		/// null.</exception>
+		/// <exception cref="ArgumentException">The hostname parameter is the empty
+		/// string.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">The value of the port parameter
+		/// is not a valid port number.</exception>
+		public XmppIm(string hostname, string server, int port = 5222, bool tls = true,
+			RemoteCertificateValidationCallback validate = null)
+		{
+			core = new XmppCore(hostname, server, port, tls, validate);
+			SetupEventHandlers();
+		}
 
         /// <summary>
         /// Establishes a connection to the XMPP server.

--- a/Sharp.Xmpp.csproj
+++ b/Sharp.Xmpp.csproj
@@ -52,10 +52,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="ARSoft.Tools.Net, Version=2.2.5.0, Culture=neutral, PublicKeyToken=1940454cd762ec57, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\Desktop\SharpXmppWpf\SharpXmppWpf\packages\ARSoft.Tools.Net.2.2.5\lib\net45\ARSoft.Tools.Net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
       <HintPath>..\..\..\..\..\Desktop\SharpXmppWpf\SharpXmppWpf\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
       <Private>True</Private>
@@ -67,6 +63,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="ARSoft.Tools.Net">
+      <HintPath>packages\ARSoft.Tools.Net.2.2.6\lib\net45\ARSoft.Tools.Net.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Client\FileTransferSettings.cs" />

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ARSoft.Tools.Net" version="2.2.5" targetFramework="net45" />
+  <package id="ARSoft.Tools.Net" version="2.2.6" targetFramework="net45" />
   <package id="BouncyCastle" version="1.8.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Added support for specifying the XMPP server to connect to when it s different from the XMPP hostname in the JID.