### PR TITLE
Use default paths for assembly references added by nuget packages

### DIFF
--- a/Sharp.Xmpp.csproj
+++ b/Sharp.Xmpp.csproj
@@ -53,11 +53,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="ARSoft.Tools.Net, Version=2.2.5.0, Culture=neutral, PublicKeyToken=1940454cd762ec57, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\Desktop\SharpXmppWpf\SharpXmppWpf\packages\ARSoft.Tools.Net.2.2.5\lib\net45\ARSoft.Tools.Net.dll</HintPath>
+      <HintPath>packages\ARSoft.Tools.Net.2.2.5\lib\net45\ARSoft.Tools.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\..\..\..\..\Desktop\SharpXmppWpf\SharpXmppWpf\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <HintPath>packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />


### PR DESCRIPTION
The `csproj` is current configured to look in the following directories for two assembly references:

```
..\..\..\..\..\Desktop\SharpXmppWpf\SharpXmppWpf\packages\ARSoft.Tools.Net.2.2.5\lib\net45\ARSoft.Tools.Net.dll
..\..\..\..\..\Desktop\SharpXmppWpf\SharpXmppWpf\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll
```

This caused me some confusion, as it's still a relative path, albeit one that is unlikely to be valid on any given developer's machine.

I am unaware of any reason that would preclude the use of the default path, which doesn't make unnecessary assumptions about the directory structure beyond the solution level.

Of course, if I've overlooked something, feel free to let me know.
