### PR TITLE
Correct misspelling of 'Authenticate'

### DIFF
--- a/Client/XmppClient.cs
+++ b/Client/XmppClient.cs
@@ -774,7 +774,7 @@ namespace Sharp.Xmpp.Client
         /// of an XMPP extension failed.</exception>
         public void Authenticate(string username, string password)
         {
-            im.Autenticate(username, password);
+            im.Authenticate(username, password);
         }
 
         /// <summary>

--- a/Im/XmppIm.cs
+++ b/Im/XmppIm.cs
@@ -402,7 +402,7 @@ namespace Sharp.Xmpp.Im
         /// <exception cref="XmppException">An XMPP error occurred while negotiating the
         /// XML stream with the server, or resource binding failed, or the initialization
         /// of an XMPP extension failed.</exception>
-        public void Autenticate(string username, string password)
+        public void Authenticate(string username, string password)
         {
             username.ThrowIfNull("username");
             password.ThrowIfNull("password");
@@ -413,6 +413,12 @@ namespace Sharp.Xmpp.Im
             Roster roster = GetRoster();
             // Send initial presence.
             SendPresence(new Presence());
+        }
+
+        [Obsolete("Use the appropriately-spelled 'Authenticate(string, string)' method instead.")]
+        public void Autenticate(string username, string password)
+        {
+            Authenticate(username, password);
         }
 
         /// <summary>


### PR DESCRIPTION
`XmppClient` contains a method named `Autenticate`, a misspelling of `Authenticate`.

As altering the API surface of the class would break backwards-compatibility, I opted to mark the existing method with `[Obsolete]` instead of deleting it.

Documentation now resides on the non-obsolete method; it was not copied.

Additionally, there was a single internal usage of the misspelled method, which I have updated.